### PR TITLE
Potential fix for code scanning alert no. 5: Clear-text logging of sensitive information

### DIFF
--- a/utils/database/setup_db.py
+++ b/utils/database/setup_db.py
@@ -84,7 +84,7 @@ def create_key_vault_secrets(prefix: str, key_vault_name: str, conn_string: str)
 
         for name, value in secrets.items():
             secret_client.set_secret(name, value)
-            logging.info(f"Secret '{name}' set in Key Vault")
+            logging.info("A secret has been set in Key Vault")
 
         logging.info(f"All secrets created in Azure Key Vault for prefix: {prefix}")
         logging.info(f"Container '{container_name}' created with a 2-year SAS token")


### PR DESCRIPTION
Potential fix for [https://github.com/coutureb/homelab/security/code-scanning/5](https://github.com/coutureb/homelab/security/code-scanning/5)

To fix the issue, we should avoid logging the names of the secrets being set in Azure Key Vault. Instead, we can log a generic message indicating that a secret has been set without including its name. This ensures that no potentially sensitive information is exposed in the logs while still providing useful feedback for debugging and monitoring purposes.

The specific changes involve replacing the log message on line 87 with a generic message that does not include the secret name. Additionally, no new imports or dependencies are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
