### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/utils/database/delete.py
+++ b/utils/database/delete.py
@@ -26,9 +26,9 @@ def delete_key_vault_secrets(prefix, key_vault_name):
         for name in secret_names:
             try:
                 secret_client.begin_delete_secret(name)
-                logging.info(f"Secret '{name}' deletion initiated in Key Vault")
+                logging.info("A secret deletion was initiated in Key Vault")
             except ResourceNotFoundError:
-                logging.info(f"Secret '{name}' not found in Key Vault")
+                logging.info("A secret was not found in Key Vault")
 
         logging.info(
             f"All secrets deletion initiated in Azure Key Vault for prefix: {prefix}"


### PR DESCRIPTION
Potential fix for [https://github.com/coutureb/homelab/security/code-scanning/1](https://github.com/coutureb/homelab/security/code-scanning/1)

To fix the issue, we will avoid logging the actual secret names. Instead, we can log a generic message indicating that a secret deletion was initiated without revealing the specific name. This ensures that no sensitive information is exposed in the logs while still providing useful operational feedback.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
