### PR TITLE
Potential fix for code scanning alert no. 4: Clear-text logging of sensitive information

### DIFF
--- a/utils/database/yaml_generator.py
+++ b/utils/database/yaml_generator.py
@@ -56,7 +56,7 @@ def create_kubernetes_config(
         )
         with open(output_path, "w") as f:
             f.write(yaml_configs)
-        logging.info(f"YAML configurations have been written to {output_path}")
+        logging.info("YAML configurations have been successfully written.")
         return output_path
     except Exception as e:
         logging.error(f"An error occurred: {e}")


### PR DESCRIPTION
Potential fix for [https://github.com/coutureb/homelab/security/code-scanning/4](https://github.com/coutureb/homelab/security/code-scanning/4)

To fix the issue, we should avoid logging the full `output_path` directly. Instead, we can log a generic success message that does not include sensitive details. If necessary, we can log a sanitized or redacted version of the `output_path` to provide some context without exposing sensitive information.

Steps to fix:
1. Replace the log message on line 59 with a generic success message or a sanitized version of `output_path`.
2. Ensure that no sensitive data from `params` (e.g., `prefix`) is exposed in the log.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
